### PR TITLE
Adding more explicit instructions on how to launch WaypointFlyer and WaypointFlyerSimple examples

### DIFF
--- a/cpp/waypoint_flier/README.md
+++ b/cpp/waypoint_flier/README.md
@@ -16,7 +16,16 @@ The package is written in C++ and features custom MRS libraries and msgs.
 ./tmux/start.sh
 ```
 
-The call the services prepared in the terminal window.
+Then, call the services prepared in the terminal window either by:
+
+1. Pressing tmux binding (`Ctrl + b` or `Ctrl + a`)
+2. Pressing the down arrow to change to the terminal below
+3. Pressing the up arrow to bring up the prepared terminal command
+
+Or typing the following command into a terminal connected to the ROS server:
+```
+rosservice call /uav1/waypoint_flier_simple/start
+```
 
 ## Package structure
 

--- a/cpp/waypoint_flier_simple/README.md
+++ b/cpp/waypoint_flier_simple/README.md
@@ -15,7 +15,16 @@ You can test the program in simulation (see our [simulation tutorial](https://ct
 ./tmux/start.sh
 ```
 
-The call the services prepared in the terminal window.
+Then, call the services prepared in the terminal window either by:
+
+1. Pressing tmux binding (`Ctrl + b` or `Ctrl + a`)
+2. Pressing the down arrow to change to the terminal below
+3. Pressing the up arrow to bring up the prepared terminal command
+
+Or typing the following command into a terminal connected to the ROS server:
+```
+rosservice call /uav1/waypoint_flier_simple/start
+```
 
 ## Package structure
 


### PR DESCRIPTION
This pull request adds some extra steps for helping others run the WaypointFlyer and WaypointFlyerSimple examples.

Since we were asked to get to know a bit the MRS System before the 2024 summer school, and the examples are referenced in the repository, I tried running them but did not know that there were extra steps aside from running the prepared `start.sh` scripts for the examples.

By adding these extra steps, on the questions/problems I had about getting the examples to run, I hope to make it easier for others to run and start tinkering with the examples by their own without having to spend time wondering why the drone does not move around in Rviz.